### PR TITLE
Remove dead duplicate AFTER_HOURS_MAX_COMPONENTS guard in ah.h

### DIFF
--- a/ah.h
+++ b/ah.h
@@ -1,7 +1,3 @@
 #pragma once
 
-#if defined(AFTER_HOURS_MAX_COMPONENTS)
-#define AFTER_HOURS_MAX_COMPONENTS 128
-#endif
-
 #include "src/ecs.h"


### PR DESCRIPTION
The guard used '#if defined' (inverted), silently clobbering an external override back to 128. It also duplicated the correct default already set in src/core/base_component.h, so just delete it.

Supersedes PR #6.

(cherry picked from commit 15cc9f243993c0afab58b2cc102ec724aceaf543)