### PR TITLE
ui: add dotted border style

### DIFF
--- a/src/plugins/ui/component_config.h
+++ b/src/plugins/ui/component_config.h
@@ -205,41 +205,45 @@ struct ComponentConfig {
     return *this;
   }
   // Float overload for backwards compatibility
-  ComponentConfig &with_border(Color color, float thickness = 2.0f) {
-    border_config = Border::all(color, pixels(thickness));
+  ComponentConfig &with_border(Color color, float thickness = 2.0f,
+                               BorderStyle style = BorderStyle::Solid) {
+    border_config = Border::all(color, pixels(thickness), style);
     return *this;
   }
   // Size overload for resolution-scaled border thickness
-  ComponentConfig &with_border(Color color, Size thickness) {
-    border_config = Border::all(color, thickness);
+  ComponentConfig &with_border(Color color, Size thickness,
+                               BorderStyle style = BorderStyle::Solid) {
+    border_config = Border::all(color, thickness, style);
     return *this;
   }
   // Per-side border methods
-  ComponentConfig &with_border_top(Color color, Size thickness = pixels(1.0f)) {
+  ComponentConfig &with_border_top(Color color, Size thickness = pixels(1.0f),
+                                   BorderStyle style = BorderStyle::Solid) {
     if (!border_config.has_value())
       border_config = Border{};
-    border_config->top = BorderSide{color, thickness};
+    border_config->top = BorderSide{color, thickness, style};
     return *this;
   }
-  ComponentConfig &with_border_right(Color color,
-                                     Size thickness = pixels(1.0f)) {
+  ComponentConfig &with_border_right(Color color, Size thickness = pixels(1.0f),
+                                     BorderStyle style = BorderStyle::Solid) {
     if (!border_config.has_value())
       border_config = Border{};
-    border_config->right = BorderSide{color, thickness};
+    border_config->right = BorderSide{color, thickness, style};
     return *this;
   }
   ComponentConfig &with_border_bottom(Color color,
-                                      Size thickness = pixels(1.0f)) {
+                                      Size thickness = pixels(1.0f),
+                                      BorderStyle style = BorderStyle::Solid) {
     if (!border_config.has_value())
       border_config = Border{};
-    border_config->bottom = BorderSide{color, thickness};
+    border_config->bottom = BorderSide{color, thickness, style};
     return *this;
   }
-  ComponentConfig &with_border_left(Color color,
-                                    Size thickness = pixels(1.0f)) {
+  ComponentConfig &with_border_left(Color color, Size thickness = pixels(1.0f),
+                                    BorderStyle style = BorderStyle::Solid) {
     if (!border_config.has_value())
       border_config = Border{};
-    border_config->left = BorderSide{color, thickness};
+    border_config->left = BorderSide{color, thickness, style};
     return *this;
   }
   ComponentConfig &with_bevel(const BevelBorder &bevel) {

--- a/src/plugins/ui/components.h
+++ b/src/plugins/ui/components.h
@@ -318,10 +318,14 @@ struct HasShadow : BaseComponent {
   explicit HasShadow(const Shadow &s) : shadow(s) {}
 };
 
+// Border line style
+enum struct BorderStyle { Solid, Dotted };
+
 // Per-side border configuration
 struct BorderSide {
   Color color = Color{0, 0, 0, 0};
   Size thickness = pixels(0.0f);
+  BorderStyle style = BorderStyle::Solid;
   bool has_border() const { return thickness.value > 0.0f && color.a > 0; }
 };
 
@@ -331,8 +335,9 @@ struct Border {
   BorderSide top, right, bottom, left;
 
   // Uniform border factory (backwards compatible)
-  static Border all(Color color, Size thickness) {
-    BorderSide s{color, thickness};
+  static Border all(Color color, Size thickness,
+                    BorderStyle style = BorderStyle::Solid) {
+    BorderSide s{color, thickness, style};
     return {s, s, s, s};
   }
 

--- a/src/plugins/ui/rendering.h
+++ b/src/plugins/ui/rendering.h
@@ -1434,7 +1434,28 @@ struct RenderImm : System<UIContext<InputAction>, FontManager> {
     if (entity.has<HasBorder>()) {
       const Border &border = entity.template get<HasBorder>().border;
       if (border.has_border()) {
-        if (border.is_uniform()) {
+        // Draw a dashed run of small rects along a side rect. Orientation is
+        // inferred from aspect: wider-than-tall = horizontal, else vertical.
+        // ponytail: dotted ignores rounded corners (four straight dashed
+        // sides).
+        auto draw_dashed = [&](float sx, float sy, float sw, float sh,
+                               float thickness, Color c) {
+          float dash = std::max(1.0f, thickness * 2.0f);
+          float gap_len = std::max(1.0f, thickness * 2.0f);
+          float step = dash + gap_len;
+          bool horizontal = sw >= sh;
+          float len = horizontal ? sw : sh;
+          for (float pos = 0.0f; pos < len; pos += step) {
+            float seg = std::min(dash, len - pos);
+            if (horizontal)
+              draw_rectangle(RectangleType{sx + pos, sy, seg, sh}, c);
+            else
+              draw_rectangle(RectangleType{sx, sy + pos, sw, seg}, c);
+          }
+        };
+        bool uniform_dotted =
+            border.is_uniform() && border.top.style == BorderStyle::Dotted;
+        if (border.is_uniform() && !uniform_dotted) {
           Color border_col = border.uniform_color();
           if (effective_opacity < 1.0f) {
             border_col = colors::opacity_pct(border_col, effective_opacity);
@@ -1442,7 +1463,7 @@ struct RenderImm : System<UIContext<InputAction>, FontManager> {
           draw_rectangle_rounded_lines(draw_rect, roundness, segments,
                                        border_col, corner_settings);
         } else {
-          // Per-side border rendering
+          // Per-side (and uniform-dotted) border rendering
           float x = draw_rect.x, y = draw_rect.y;
           float w = draw_rect.width, h = draw_rect.height;
           auto draw_side = [&](const BorderSide &side, float sx, float sy,
@@ -1452,7 +1473,10 @@ struct RenderImm : System<UIContext<InputAction>, FontManager> {
             Color c = side.color;
             if (effective_opacity < 1.0f)
               c = colors::opacity_pct(c, effective_opacity);
-            draw_rectangle(RectangleType{sx, sy, sw, sh}, c);
+            if (side.style == BorderStyle::Dotted)
+              draw_dashed(sx, sy, sw, sh, side.thickness.value, c);
+            else
+              draw_rectangle(RectangleType{sx, sy, sw, sh}, c);
           };
           float tt = border.top.thickness.value;
           float bt = border.bottom.thickness.value;
@@ -2028,7 +2052,28 @@ struct RenderBatched : System<UIContext<InputAction>, FontManager> {
     if (entity.has<HasBorder>()) {
       const Border &border = entity.template get<HasBorder>().border;
       if (border.has_border()) {
-        if (border.is_uniform()) {
+        // Add a dashed run of small rects along a side rect. Orientation is
+        // inferred from aspect: wider-than-tall = horizontal, else vertical.
+        // ponytail: dotted ignores rounded corners (four straight dashed
+        // sides).
+        auto add_dashed = [&](float sx, float sy, float sw, float sh,
+                              float thickness, Color c) {
+          float dash = std::max(1.0f, thickness * 2.0f);
+          float gap_len = std::max(1.0f, thickness * 2.0f);
+          float step = dash + gap_len;
+          bool horizontal = sw >= sh;
+          float len = horizontal ? sw : sh;
+          for (float pos = 0.0f; pos < len; pos += step) {
+            float seg = std::min(dash, len - pos);
+            RectangleType r = horizontal ? RectangleType{sx + pos, sy, seg, sh}
+                                         : RectangleType{sx, sy + pos, sw, seg};
+            buffer.add_rounded_rectangle(r, c, 0.f, 1, corner_settings, layer,
+                                         entity.id, 0.f);
+          }
+        };
+        bool uniform_dotted =
+            border.is_uniform() && border.top.style == BorderStyle::Dotted;
+        if (border.is_uniform() && !uniform_dotted) {
           Color border_col = border.uniform_color();
           if (effective_opacity < 1.0f) {
             border_col = colors::opacity_pct(border_col, effective_opacity);
@@ -2037,7 +2082,7 @@ struct RenderBatched : System<UIContext<InputAction>, FontManager> {
                                                segments, corner_settings, layer,
                                                entity.id);
         } else {
-          // Per-side border rendering (as filled rectangles)
+          // Per-side (and uniform-dotted) border rendering (filled rectangles)
           float x = draw_rect.x, y = draw_rect.y;
           float w = draw_rect.width, h = draw_rect.height;
           auto add_side = [&](const BorderSide &side, float sx, float sy,
@@ -2047,6 +2092,10 @@ struct RenderBatched : System<UIContext<InputAction>, FontManager> {
             Color c = side.color;
             if (effective_opacity < 1.0f)
               c = colors::opacity_pct(c, effective_opacity);
+            if (side.style == BorderStyle::Dotted) {
+              add_dashed(sx, sy, sw, sh, side.thickness.value, c);
+              return;
+            }
             RectangleType side_rect{sx, sy, sw, sh};
             buffer.add_rounded_rectangle(side_rect, c, 0.f, 1, corner_settings,
                                          layer, entity.id, 0.f);


### PR DESCRIPTION
Add BorderStyle{Solid,Dotted} on BorderSide, thread an optional style through Border::all and all with_border* builders (Solid default, so existing callers are unchanged). Render Dotted as a dashed run of small rects along each side (dash=gap=thickness*2) in both the direct-draw and buffered border renderers; dotted ignores rounded corners.

(cherry picked from commit aa63a27cb44b2c6493d90678dde8ecc2eb8e1905)