### PR TITLE
perf(input): O(1) input-collector lookup + drop per-frame vector copy

### DIFF
--- a/src/plugins/input_system.h
+++ b/src/plugins/input_system.h
@@ -1058,14 +1058,11 @@ struct input : developer::Plugin {
     };
 
     static auto get_input_collector() -> PossibleInputCollector {
-        // TODO replace with a singletone query
-        OptEntity opt_collector =
-            EntityQuery({.ignore_temp_warning = true})
-                .template whereHasComponent<InputCollector>()
-                .gen_first();
-        if (!opt_collector.valid()) return {};
-        Entity &collector = opt_collector.asE();
-        return collector.get<InputCollector>();
+        // InputCollector is a singleton; guard returns empty when absent.
+        if (!EntityHelper::has_singleton<InputCollector>()) return {};
+        InputCollector *ic = EntityHelper::get_singleton_cmp<InputCollector>();
+        if (ic == nullptr) return {};
+        return *ic;
     }
 
     // TODO i would like to move this out of input namespace
@@ -1108,7 +1105,7 @@ struct input : developer::Plugin {
 
             for (const auto &kv : input_mapper.mapping) {
                 const int action = kv.first;
-                const ValidInputs vis = kv.second;
+                const ValidInputs &vis = kv.second;
 
                 int i = 0;
                 do {

--- a/src/plugins/input_system.h
+++ b/src/plugins/input_system.h
@@ -1058,7 +1058,6 @@ struct input : developer::Plugin {
     };
 
     static auto get_input_collector() -> PossibleInputCollector {
-        // InputCollector is a singleton; guard returns empty when absent.
         if (!EntityHelper::has_singleton<InputCollector>()) return {};
         InputCollector *ic = EntityHelper::get_singleton_cmp<InputCollector>();
         if (ic == nullptr) return {};


### PR DESCRIPTION
Benchmark-driven perf pass on `src/plugins/input_system.h`, part of the `docs/speed/` effort.

## Wins (2, both behavior-preserving by construction)
- **`get_input_collector` via singleton lookup, not full entity scan** — was an `EntityQuery` scanning every entity *every frame*, called from 4 UI systems. `InputCollector` is a registered singleton → O(entities)→O(1). A `has_singleton` guard preserves the exact empty-optional behavior (naive swap would crash when no collector exists). Resolves an in-code TODO.
- **Avoid per-frame `ValidInputs` vector copy** in `InputSystem` — a per-action-per-frame heap copy → `const&`.

## Rejected (with reasoning, in the ledger)
HIGH #2 (cache `get_mouse_position` math) rejected — called ~once/frame, ~15 float ops, a cache needs frame-boundary invalidation that doesn't exist and invites a stale-cursor-after-resize bug. The hot path is already clean (templated dispatch, no `std::function`, retained-capacity vectors).

## Verification
Adds `tests/input_system_resolution_test.cpp` (locks resolved action set + values across 5 scenarios) + a mapping-resolution benchmark. Compile-clean across raylib/metal/stub backends. ⚠️ Could not run on the dev machine (Santa Lockdown SIGKILLs fresh binaries) — the resolved-actions-identical guarantee is by construction (copy→ref, equivalent O(1) lookup with same empty-case). No numbers fabricated.

`docs/speed/input.md` rewritten as a DONE/REJECTED/DEFERRED ledger.
