### PR TITLE
perf(ecs): allocation-free for_each_stream + O(1) shared-ptr lookup

### DIFF
--- a/src/core/entity_collection.h
+++ b/src/core/entity_collection.h
@@ -539,6 +539,27 @@ struct EntityCollection {
     auto opt_ent = getEntityForID(id);
     return opt_ent.asE();
   }
+
+  // Fast path is the O(1) id_to_slot lookup; the scan is a fallback for
+  // entities whose slot mapping is stale or absent (e.g. not yet merged).
+  std::shared_ptr<Entity> getEntityAsSharedPtr(const Entity &entity) const {
+    const EntityID id = entity.id;
+    if (id >= 0) {
+      const std::size_t idx = static_cast<std::size_t>(id);
+      if (idx < id_to_slot.size()) {
+        const EntityHandle::Slot slot = id_to_slot[idx];
+        if (slot != EntityHandle::INVALID_SLOT && slot < slots.size()) {
+          if (const auto &sp = slots[slot].ent; sp && sp->id == id)
+            return sp;
+        }
+      }
+    }
+    for (const std::shared_ptr<Entity> &current_entity : get_entities()) {
+      if (entity.id == current_entity->id)
+        return current_entity;
+    }
+    return {};
+  }
 };
 
 } // namespace afterhours

--- a/src/core/entity_helper.h
+++ b/src/core/entity_helper.h
@@ -109,7 +109,9 @@ struct EntityHelper {
 
   static RefEntities get_ref_entities() {
     RefEntities matching;
-    for (const auto &e : get_entities()) {
+    const auto &ents = get_entities();
+    matching.reserve(ents.size());
+    for (const auto &e : ents) {
       if (!e)
         continue;
       matching.push_back(*e);
@@ -186,11 +188,7 @@ struct EntityHelper {
   }
 
   static std::shared_ptr<Entity> getEntityAsSharedPtr(const Entity &entity) {
-    for (const std::shared_ptr<Entity> &current_entity : get_entities()) {
-      if (entity.id == current_entity->id)
-        return current_entity;
-    }
-    return {};
+    return get_default_collection().getEntityAsSharedPtr(entity);
   }
 
   static std::shared_ptr<Entity> getEntityAsSharedPtr(const OptEntity entity) {

--- a/src/core/entity_query.h
+++ b/src/core/entity_query.h
@@ -375,6 +375,31 @@ struct EntityQuery {
     }
   }
 
+  // Like for_each() but visits entities without materializing a RefEntities
+  // vector. An orderby needs the full set, so delegate to gen() in that case.
+  template <typename Fn> void for_each_stream(Fn &&fn) const {
+    if (orderby) {
+      for (Entity &entity : gen()) {
+        std::invoke(std::forward<Fn>(fn), entity);
+      }
+      return;
+    }
+    for (const auto &e_ptr : entities) {
+      if (!e_ptr)
+        continue;
+      Entity &e = *e_ptr;
+      bool ok = true;
+      for (const auto &mod : mods) {
+        if (!mod(e)) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok)
+        std::invoke(fn, e);
+    }
+  }
+
   template <typename Component>
   [[nodiscard]] std::vector<std::reference_wrapper<Component>> gen_as() const {
     const auto results = gen();


### PR DESCRIPTION
Benchmark-driven perf pass on the core ECS (`entity_query.h`, `entity_helper.h`, `entity_collection.h`), part of the `docs/speed/` effort. **Conservative — the foundation's correctness dwarfs any perf gain.**

## Wins (3, surgical + provably behavior-identical)
- **`EntityQuery::for_each_stream`** — additive method: runs filters inline and calls `fn(Entity&)` directly, skipping the `RefEntities` materialization (1 heap alloc of N ref-wrappers/call). Kept **separate** from `for_each()` to avoid `gen()`'s caching contract + stateful `take()/first()` counter; falls back to `gen()` when `orderby` is set. Locked: `for_each_stream == for_each` order+membership.
- **`getEntityAsSharedPtr` O(N)→O(1)** — added the `id_to_slot → slots[].ent` fast path (same structure `getEntityForID` uses); linear scan retained as fallback → byte-identical result + shared_ptr identity.
- **`get_ref_entities` reserve** — eliminates realloc churn; contents/order unchanged.

## Rejected / Deferred (with reasoning)
- **REJECTED #7 bitset-mask component match (the headline idea)** — analytically a *pessimization* for the dominant K=1/K=2 systems (one word-op short-circuit vs ~6 for mask+negation), only wins at K≥3 (rare), adds correctness risk. Cargo-cult "bitset is faster" without the K distribution.
- **DEFERRED (architectural, out of scope):** SoA/archetype storage + dropping `shared_ptr<Entity>` (the real win, but rearchitects storage/handles/queries/snapshots at once); CRTP/type-erased dispatch replacing virtual `for_each_with`; per-component entity indices (changes observable iteration order). All deferred behind the behavior lock this branch establishes.

## Verification
Adds `tests/core_ecs_behavior_test.cpp` (18 tests locking query all/filter/two-filter/missing/first/count/take/orderby/tags order+identity-exact, tick+merge visibility, singleton, lifecycle, getEntityForID, shared_ptr identity) + a `SystemManager::tick` benchmark. Compile-clean. ⚠️ Could not run (Santa Lockdown) — wins are provably-identical transforms; no numbers fabricated.

**Note:** flagged a latent correctness bug found during review — see #41 (`tags_ok` `#if __APPLE__` guard drops tag filtering off-Mac). Not addressed here.

`docs/speed/core_ecs.md` rewritten as a DONE/REJECTED/DEFERRED ledger.
