### PR TITLE
perf(autolayout): drop dead compute + reuse child list in tax_refund

### DIFF
--- a/src/plugins/autolayout.h
+++ b/src/plugins/autolayout.h
@@ -743,16 +743,11 @@ struct AutoLayout {
     }
   }
 
-  void tax_refund(UIComponent &widget, Axis axis, float error) {
-    SmallVector<UIComponent *, 16> layout_children;
-    for (EntityID child_id : widget.children) {
-      UIComponent &child = cmp(child_id);
-      // Dont worry about any children that are absolutely positioned
-      // Ignore anything that should be hidden
-      if (child.absolute || child.should_hide)
-        continue;
-      layout_children.push_back(&child);
-    }
+  // `layout_children` is the caller's already-filtered child list, reused here
+  // so we don't re-walk and re-filter widget.children on each axis.
+  void tax_refund(UIComponent &widget, Axis axis, float error,
+                  const SmallVector<UIComponent *, 16> &layout_children) {
+    (void)widget;
 
     // First, check for Expand children and distribute to them
     float total_expand_weight = 0.f;
@@ -801,6 +796,19 @@ struct AutoLayout {
       // continue;
       // }
     }
+  }
+
+  void tax_refund(UIComponent &widget, Axis axis, float error) {
+    SmallVector<UIComponent *, 16> layout_children;
+    for (EntityID child_id : widget.children) {
+      UIComponent &child = cmp(child_id);
+      // Dont worry about any children that are absolutely positioned
+      // Ignore anything that should be hidden
+      if (child.absolute || child.should_hide)
+        continue;
+      layout_children.push_back(&child);
+    }
+    tax_refund(widget, axis, error, layout_children);
   }
 
   void solve_violations(UIComponent &widget) {
@@ -990,12 +998,12 @@ struct AutoLayout {
     // Main axis: Row→X, Column→Y. Cross axis uses max (overlap).
     float error_x = compute_error(Axis::X, is_rw);
     if (error_x < 0) {
-      tax_refund(widget, Axis::X, error_x);
+      tax_refund(widget, Axis::X, error_x, layout_children);
     }
 
     float error_y = compute_error(Axis::Y, is_col);
     if (error_y < 0) {
-      tax_refund(widget, Axis::Y, error_y);
+      tax_refund(widget, Axis::Y, error_y, layout_children);
     }
 
     // Apply min/max constraints after size computation and error distribution
@@ -1374,18 +1382,10 @@ struct AutoLayout {
                  cy, child_end_x, child_end_y, sx, sy, gap, start_offset);
       }
 
-      constexpr float GRID_UNIT_720P = 4.0f;
-      float grid_unit_y =
-          GRID_UNIT_720P * (fetch_screen_value_(Axis::Y) / 720.0f);
-      float grid_unit_x =
-          GRID_UNIT_720P * (fetch_screen_value_(Axis::X) / 720.0f);
-
       // Setup for next child placement (include gap for justify)
       if (is_column) {
         float next_y = offy + cy + gap;
-        // Note: We no longer add grid_unit_y here - it was causing
-        // accumulated offset that breaks justify calculations.
-        // Grid snapping now only affects final position, not child spacing.
+        // Snap only the final position, not the inter-child spacing accumulator.
         if (enable_grid_snapping) {
           next_y = snap_to_8pt_grid(next_y, Axis::Y);
         }
@@ -1393,9 +1393,7 @@ struct AutoLayout {
       }
       if (is_row) {
         float next_x = offx + cx + gap;
-        // Note: We no longer add grid_unit_x here - it was causing
-        // accumulated offset that breaks justify calculations.
-        // Grid snapping now only affects final position, not child spacing.
+        // Snap only the final position, not the inter-child spacing accumulator.
         if (enable_grid_snapping) {
           next_x = snap_to_8pt_grid(next_x, Axis::X);
         }


### PR DESCRIPTION
Benchmark-driven perf pass on `src/plugins/autolayout.h`, part of the `docs/speed/` effort. The file was already well-optimized on main (flat O(1) cmp_cache, fused passes, SmallVector, no `std::function` in the hot path) — several doc items were already done.

## Wins (2, airtight + behavior-identical)
- **Drop dead per-child `grid_unit_x/y` compute** in `compute_relative_positions` — computed every child but had no readers (`-Wunused-variable`). −2 `fetch_screen_value_()` calls + 4 float ops per child from the hottest walk. (Honest: `-O3` likely already DCE'd these; value is an optimizer-independent, warning-clean removal.)
- **Reuse `solve_violations`' filtered child list in `tax_refund`** — `tax_refund` rebuilt the identical `layout_children` list per axis; now takes it by `const&`. Removes up to 2 redundant O(children) walks + SmallVector fills per slack widget (common with `expand()`). Same predicate/order/pointers → no rect can change.

## Deferred (correctness-critical, unverifiable under Santa)
Dirty-flag (immediate-mode rebuilds every frame; a stale rect is a visible bug), skip-hidden-subtrees (same risk), and fusing the remaining 6 passes (real ordering deps) — all need runtime verification we can't do here.

## Verification
Adds `tests/autolayout_golden_rect_test.cpp` pinning the full (x,y,w,h) of every node of two hand-derived trees, alongside the existing 129-test autolayout suite. Also fixed the test/bench build harness (stale include depth, hardcoded raylib path, and a `<afterhours/...>`→sibling-worktree resolution bug — see #42; the shim is build-time-generated + gitignored, not committed). Compile-clean. ⚠️ Could not run (Santa Lockdown) — both wins are behavior-preserving transforms; no numbers fabricated.

`docs/speed/ui_autolayout.md` rewritten as a DONE/REJECTED/DEFERRED ledger.
