### PR TITLE
docs(animation): name the source file for the speed items

### DIFF
--- a/docs/speed/animation.md
+++ b/docs/speed/animation.md
@@ -1,5 +1,9 @@
 # Animation Plugin
 
+> Source: `src/plugins/animation.h` (`AnimationManager`, `AnimTrack`, `AnimSegment`).
+> Note: `src/plugins/ui/animation_config.h` is a separate fluent config builder and is
+> **not** the optimization surface for the items below.
+
 1. **HIGH — Use a contiguous array of active tracks instead of iterating all tracks in the hash map.**
    `AnimationManager::update()` iterates every track, including inactive ones. Maintain a separate list of active track keys for O(active) instead of O(total).
 


### PR DESCRIPTION
`docs/speed/animation.md` describes items in `AnimationManager::update` / `AnimTrack` / `on_complete`, which live in `src/plugins/animation.h` — **not** the similarly-named `src/plugins/ui/animation_config.h` (a fluent config builder with none of these hotspots). This caused a perf-review pass to initially target the wrong file.

Adds a one-line source pointer to the doc header so readers optimize the right file. Doc-only.
