### PR TITLE
fix(tests): pin <afterhours/...> include to this checkout, not a sibling (#42 pt 2/3)

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+.afh-include/

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,9 +24,18 @@ BREW_PREFIX := $(shell brew --prefix 2>/dev/null)
 ifeq ($(BREW_PREFIX),)
     BREW_PREFIX := /opt/homebrew
 endif
-AFTERHOURS_ROOT := ..
+# Pin <afterhours/...> to THIS checkout regardless of the directory's name.
+# A bare `-isystem ../..` resolves <afterhours/...> to the *parent* of the
+# checkout dir, which only works when the checkout is literally named
+# `afterhours`. In a git worktree (or any differently-named clone) that silently
+# picks up a *sibling* `afterhours` checkout, so tests compile against the wrong
+# source. Generate a private include dir containing a symlink named exactly
+# `afterhours` -> this checkout root, and use it as the sole afterhours root.
+AFTERHOURS_ROOT := $(realpath ..)
+INCLUDE_ROOT := $(CURDIR)/.afh-include
+$(shell mkdir -p $(INCLUDE_ROOT) && ln -sfn $(AFTERHOURS_ROOT) $(INCLUDE_ROOT)/afterhours)
 
-INCLUDES := -isystem $(AFTERHOURS_ROOT)/.. -isystem $(BREW_PREFIX)/include
+INCLUDES := -isystem $(INCLUDE_ROOT) -isystem $(AFTERHOURS_ROOT)/vendor -isystem $(BREW_PREFIX)/include
 INCLUDES_RAYLIB := -I$(RAYLIB_INCLUDE) $(INCLUDES)
 
 UNAME_S := $(shell uname -s)
@@ -107,3 +116,4 @@ test: all
 
 clean:
 	rm -f $(ALL_TESTS) input_system_mouse_delta_backend_smoke.o smoke_raylib.o smoke_sokol.o
+	rm -rf $(INCLUDE_ROOT)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -76,7 +76,7 @@ autolayout_test: autolayout_test.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@
 
 entity_mapping_test: entity_mapping_test.cpp ../examples/entity_mapping_test_helper.cpp
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -I../examples $^ -o $@
 
 entity_pool_test: entity_pool_test.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@


### PR DESCRIPTION
Finishes **#42**. PR #46 fixed parts 1 & 3 (Homebrew prefix auto-detect, fmt include). This is the dangerous **part 2**: the sibling-checkout hazard.

## Problem
`INCLUDES := -isystem $(AFTERHOURS_ROOT)/..` with `AFTERHOURS_ROOT := ..` resolves `#include <afterhours/...>` to the **parent of the checkout dir**. That only works when the checkout is literally named `afterhours`. In a **git worktree** (e.g. `afterhours-mkfix`) or any differently-named clone, `../..` silently pulls headers from a *sibling* `afterhours` checkout — so tests compile against the **wrong source** and pass/fail based on code that isn't under test. Silent and nasty.

## Fix
Generate a private `tests/.afh-include/` dir containing a symlink named exactly `afterhours` → this checkout root, and use it as the sole afterhours include root. Now `<afterhours/...>` always resolves to **this** tree regardless of the directory's name. Also added `-isystem $(AFTERHOURS_ROOT)/vendor` so the vendored `magic_enum` resolves from this tree (it was previously masked by the sibling resolution). `.afh-include/` is gitignored; `make clean` removes it.

## Verification
- **Sibling-hazard proof**: with a poisoned sibling `~/p/afterhours` present and a unique sentinel added to *this* worktree's `ah.h`, the sentinel is picked up via the NEW root (1 hit) but NOT via the OLD `../..` root (0 hits — it grabbed the wrong sibling). Confirms the bug and the fix.
- All non-raylib tests (`autolayout`, `entity_query`, `entity_pool`, `input_injector_mouse_delta`) compile clean through the Makefile.
- A raylib test (`slider_test`) compiles clean (0 errors; link skipped — dev box has Santa Lockdown, unrelated to this change).

Closes #42 (with #46).