### PR TITLE
fix(ui): const char* font sentinels instead of constexpr std::string (portability)

### DIFF
--- a/src/plugins/ui/ui_core_components.h
+++ b/src/plugins/ui/ui_core_components.h
@@ -24,9 +24,14 @@ namespace ui {
 struct AutoLayoutRoot : BaseComponent {};
 
 struct UIComponent : BaseComponent {
-  static constexpr std::string UNSET_FONT = "__unset";
-  static constexpr std::string DEFAULT_FONT = "__default";
-  static constexpr std::string SYMBOL_FONT = "__symbol";
+  // Sentinel font names. Kept as `const char*` (not `constexpr std::string`,
+  // which needs libstdc++-13 / libc++-15) so the UI plugin builds on older but
+  // C++20-capable toolchains (e.g. gcc 11/12). They're only used as opaque
+  // sentinels — compared against std::string and passed to load_font/enable_font
+  // (which take const std::string&, so const char* converts implicitly).
+  static constexpr const char *UNSET_FONT = "__unset";
+  static constexpr const char *DEFAULT_FONT = "__default";
+  static constexpr const char *SYMBOL_FONT = "__symbol";
 
   EntityID id;
   UIComponent() { init_values(); }


### PR DESCRIPTION
## Problem
`UIComponent::UNSET_FONT / DEFAULT_FONT / SYMBOL_FONT` were `static constexpr std::string`. `constexpr std::string` requires **libstdc++-13 / libc++-15** — the exact same too-new-stdlib portability class that #48 just fixed for `<format>`. On an older but C++20-capable toolchain (gcc 11/12, common on Linux/CI) it's a hard compile error, reached by anything that pulls the UI plugin: `autolayout_test`, `entity_mapping_test`, and the consumer games.

## Fix
Make them `static constexpr const char*`. They're only used as **opaque sentinels** — compared against `std::string` (`font_name != UNSET_FONT`), assigned to `std::string`, and passed to `load_font`/`enable_font` (which take `const std::string&`, so `const char*` converts implicitly). No `.size()`/`.substr()`/concatenation, no constexpr-value dependency — so `const char*` is a clean drop-in that works on every C++17+ toolchain, with no runtime string construction.

## Verification
- Micro-test: all three usage patterns (assign / compare / pass-to-`const std::string&`) compile clean with `const char*`.
- `autolayout_test` (pulls the UI plugin + these constants) compiles **0 errors** — it was one of two files failing on the gcc-11 box.
- kart consumer main TU compiles 0 errors.

## How found
Surfaced while validating the CI recipe (#53) on a real gcc-11 / no-`<format>` Linux box: #48's `<format>` fallback worked (confirmed), but this `constexpr std::string` was a *second*, unguarded landmine of the same class. Fixing it makes the UI plugin actually portable to the toolchains #48 targets. Pairs with #48.