### PR TITLE
perf(build): split translation::Language into language.h so the UI path skips fmt

### DIFF
--- a/src/plugins/language.h
+++ b/src/plugins/language.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Lightweight home for the translation Language enum, split out of
+// translation.h so headers that only need the enum (e.g. ui/theme.h, pulled by
+// most of the UI plugin) don't drag in translation.h's heavy fmt dependency
+// (<fmt/args.h> + <fmt/format.h>, ~0.4s to parse per TU). translation.h itself
+// includes this, so existing users are unaffected.
+
+namespace afterhours {
+namespace translation {
+
+enum struct Language { English, Korean, Japanese };
+
+} // namespace translation
+} // namespace afterhours

--- a/src/plugins/translation.h
+++ b/src/plugins/translation.h
@@ -15,12 +15,14 @@
 #include "../core/entity_helper.h"
 #include "../core/entity_query.h"
 #include "../developer.h"
+#include "language.h" // translation::Language (kept here so existing users are unaffected)
 #include "../logging.h"
 
 namespace afterhours {
 namespace translation {
 
-enum struct Language { English, Korean, Japanese };
+// Language enum lives in language.h so enum-only consumers (ui/theme.h) avoid
+// this file's fmt dependency.
 
 template <typename ParamEnum> class TranslatableString {
 public:

--- a/src/plugins/ui/theme.h
+++ b/src/plugins/ui/theme.h
@@ -5,9 +5,14 @@
 #include <cmath>
 #include <map>
 #include <string>
+#if __has_include(<magic_enum/magic_enum.hpp>)
+#include <magic_enum/magic_enum.hpp>
+#else
+#include "../../../vendor/magic_enum/magic_enum.hpp"
+#endif
 
 #include "../color.h"
-#include "../translation.h"
+#include "../language.h" // only needs translation::Language, not translation.h's fmt-heavy machinery
 
 namespace afterhours {
 


### PR DESCRIPTION
## Problem
`ui/theme.h` only uses the `translation::Language` enum (a 3-value enum), but it included the whole `translation.h` — which pulls `<fmt/args.h>` + `<fmt/format.h>` (the fmt library) for its `TranslatableString` machinery. `theme.h` is included by **~10 core UI headers** (component_config, systems, context, rendering, ui_core_components, components, styling_defaults, …), so **every UI TU paid the fmt parse cost just to name a 3-value enum**. (This is why the UI path was flat in #48's measurements — fmt dominated it.)

## Fix
- Extract `enum struct Language` into a tiny `plugins/language.h` (zero heavy deps).
- `theme.h` includes `language.h` instead of `translation.h` → fmt is now entirely absent from the UI include path (verified via `-H`).
- `translation.h` includes `language.h` too, so its existing users are unaffected.
- Added `theme.h`'s own `magic_enum` include (it used `magic_enum::enum_name` via translation.h transitively; now included directly — include-what-you-use, matching the codebase's `__has_include` brew/vendored pattern).

## Measured
- `theme.h` alone: **0.80s → 0.74s** (min of 3, -fsyntax-only). Modest per-TU (theme.h already pulls `<map>`/`<string>`/magic_enum that overlap fmt's transitive deps), but fmt is now **fully off the UI path**, which compounds across a full build.
- The bigger point is correctness of structure: theme.h shouldn't depend on the translation *runtime* to name an enum.

## Verification
- `theme.h` compiles via both brew and vendored magic_enum paths.
- Full metal demo + kart consumer main TU compile 0 errors.
- Checked (post-#48 systems.h lesson) that no file relied on theme.h to supply `translation::` transitively — none do.