### PR TITLE
fix(sokol): free GPU objects + bail when texture image/view creation fails

### DIFF
--- a/src/backends/sokol/drawing_helpers.h
+++ b/src/backends/sokol/drawing_helpers.h
@@ -1280,11 +1280,25 @@ inline TextureType load_texture_from_pixels(const unsigned char *rgba, int w,
       static_cast<size_t>(w) * static_cast<size_t>(h) * 4u;
   id.label = "tex-image";
   sg_image img = sg_make_image(&id);
+  if (sg_query_image_state(img) != SG_RESOURCESTATE_VALID) {
+    // Image creation failed (e.g. GPU OOM or sokol image pool exhausted).
+    // Bail before making the view/sampler — otherwise those GPU objects leak
+    // (the caller gets an empty TextureType and won't unload_texture it).
+    log_error("load_texture_from_pixels: sg_make_image failed ({}x{})", w, h);
+    sg_destroy_image(img); // safe on a failed image; frees the pool slot
+    return TextureType{};
+  }
 
   sg_view_desc vd{};
   vd.texture.image = img;
   vd.label = "tex-view";
   sg_view view = sg_make_view(&vd);
+  if (sg_query_view_state(view) != SG_RESOURCESTATE_VALID) {
+    log_error("load_texture_from_pixels: sg_make_view failed ({}x{})", w, h);
+    sg_destroy_view(view);
+    sg_destroy_image(img);
+    return TextureType{};
+  }
 
   sg_sampler smp = make_sampler_for_filter(filter);
 


### PR DESCRIPTION
## Problem
`load_texture_from_pixels` (the shared core of `load_texture` / `load_texture_with_color_key`) did:
```
sg_image img = sg_make_image(&id);      // unchecked
sg_view view = sg_make_view(&vd);       // unchecked, references img
sg_sampler smp = make_sampler_for_filter(filter);
// ... return a TextureType with img.id/view.id/smp.id
```
If `sg_make_image` fails (GPU OOM, sokol image-pool exhaustion), it still builds a view over the invalid image and returns a `TextureType` with a **garbage `img_id` that looks valid** to the caller. Two consequences:
1. **GPU-object leak**: the caller thinks it got a normal texture, so it never `unload_texture()`s it → the view + sampler leak.
2. Draws with it silently fail.

## Fix
Check `sg_query_image_state(img) == SG_RESOURCESTATE_VALID` (and the same for the view) after each `sg_make_*`. On failure: destroy whatever was created and return an empty `TextureType{}` — the documented failure sentinel. No leak, clear signal to the caller.

## Verification
- `sg_query_view_state` / `sg_destroy_view` exist in the vendored sokol (checked).
- Full metal demo, including the `SOKOL_IMPL` TU with real `sg_*` bodies, compiles clean.

## Follow-up (intentionally not in this PR)
The render-target path (`create_render_target`, ~L943) makes 2 images + 3 views + 1 sampler with the same unchecked pattern — same leak class but a larger, cascading-cleanup fix. Flagged for a separate PR to keep this one focused on the public texture-load API (the realistic consumer footgun). Continues the correctness pass alongside #56.