### PR TITLE
fix(sokol): validate dimensions in metal_read_image_pixels (overflow/heap safety)

### DIFF
--- a/src/backends/sokol/capture_impl.h
+++ b/src/backends/sokol/capture_impl.h
@@ -68,6 +68,15 @@ static id<MTLTexture> metal_resolve_msaa(id<MTLTexture> src) {
 // Returns nullptr on failure. Handles both MSAA and non-MSAA textures.
 static uint8_t *metal_read_image_pixels(sg_image img_id, int width,
                                         int height) {
+  // Guard invalid dimensions: width/height <= 0 would malloc(0) + read a
+  // zero/negative MTLRegion, and a huge width*height*4 can overflow size_t and
+  // under-allocate, so getBytes then writes past the buffer (heap corruption).
+  if (width <= 0 || height <= 0)
+    return nullptr;
+  const size_t px = static_cast<size_t>(width) * static_cast<size_t>(height);
+  if (px > SIZE_MAX / 4u) // width*height*4 (RGBA8) would overflow
+    return nullptr;
+
   sg_mtl_image_info info = sg_mtl_query_image_info(img_id);
   id<MTLTexture> tex =
       (__bridge id<MTLTexture>)info.tex[info.active_slot];


### PR DESCRIPTION
## Problem
`metal_read_image_pixels` (the capture pixel-readback) takes `width`/`height` straight from `rt.width`/`rt.height` via `capture_render_texture`, with **no validation**. Two hazards:
1. `width <= 0` or `height <= 0` → `malloc(0)` + a zero/negative `MTLRegion` `getBytes:`.
2. A large `width * height * 4` **overflows `size_t`**, under-allocating the buffer — then `getBytes:` writes the real `width*height*4` bytes past it → **heap corruption**.

## Fix
Guard at the top of `metal_read_image_pixels`:
- reject `width <= 0 || height <= 0`
- reject pixel counts where `px * 4` (RGBA8) would exceed `SIZE_MAX`

Returns `nullptr` — the existing failure sentinel that all callers (`metal_capture_render_texture`, `..._to_memory`) already handle. No behavior change on the valid path.

## Verification
- `tools/headless_capture/sokol_impl.mm` (which includes `capture_impl.h`) compiles clean.
- Audited the rest of the capture path while here: `metal_read_image_pixels` (malloc checked, caller frees), `metal_capture_render_texture` (frees on both paths), and `metal_write_png` (releases ctx/cg_img/dest/colorspace on every error path) are all already correct — this dimension guard was the one gap.

Continues the sokol GPU-resource correctness pass alongside #57 (texture-load leak) and #58 (render-target leak).