### PR TITLE
fix(sokol): guard zero-sweep in draw_circle_sector[_lines] (NaN stepLength)

### DIFF
--- a/src/backends/sokol/drawing_helpers.h
+++ b/src/backends/sokol/drawing_helpers.h
@@ -690,6 +690,9 @@ inline void draw_circle_lines(int centerX, int centerY, float radius,
 inline void draw_circle_sector(Vector2Type center, float radius,
                                float startAngle, float endAngle, int segments,
                                Color color) {
+  if (startAngle == endAngle)
+    return; // zero sweep: nothing to draw (matches draw_ring_segment; also
+            // avoids a 0/0 = NaN stepLength when segments is 0)
   if (radius <= 0.0f)
     radius = 0.1f;
 
@@ -730,6 +733,9 @@ inline void draw_circle_sector(Vector2Type center, float radius,
 inline void draw_circle_sector_lines(Vector2Type center, float radius,
                                      float startAngle, float endAngle,
                                      int segments, Color color) {
+  if (startAngle == endAngle)
+    return; // zero sweep: nothing to draw (matches draw_ring_segment; also
+            // avoids a 0/0 = NaN stepLength when segments is 0)
   if (radius <= 0.0f)
     radius = 0.1f;
 


### PR DESCRIPTION
## Problem
`draw_ring_segment` already early-returns when `startAngle == endAngle`, but `draw_circle_sector` and `draw_circle_sector_lines` didn't. With a zero sweep:
- `minSegments = ceilf((endAngle-startAngle)/90) = ceilf(0) = 0`
- if the caller also passes `segments <= 0`, the `segments < minSegments` (`<= 0 < 0` = false) recompute is skipped
- → `stepLength = 0.0f / 0.0f = NaN` → fed to `cosf`/`sinf` → NaN vertices emitted to sokol_gl.

Even with `segments > 0` a zero sweep just draws degenerate zero-area geometry.

## Fix
Add the same `if (startAngle == endAngle) return;` guard the ring path already has, to both circle-sector functions — consistent behavior (a zero-sweep sector draws nothing) and NaN-safe.

## Verification
- Metal demo compiles clean (+6 lines).
- Audited the sibling geometry primitives I added in #29 while here — all already safe: `draw_ring_segment` (has the guard), `draw_poly`/`draw_poly_lines`/`draw_poly_lines_ex` (`sides < 3` → 3 clamp, no div-by-zero), `draw_ellipse`/`draw_ellipse_lines` (fixed 36 segments). This zero-sweep case in the two circle-sector functions was the one gap.

Continues the sokol correctness pass (#57 texture-load, #58 render-target, #59 capture-dims).