### PR TITLE
docs(sokol): correct stale sgl sample_count TODO in sokol_init_cb

### DIFF
--- a/src/backends/sokol/backend.h
+++ b/src/backends/sokol/backend.h
@@ -136,11 +136,12 @@ inline void sokol_init_cb() {
   sg_desc desc{};
   desc.environment = sglue_environment();
   desc.logger.func = slog_func;
-  // TODO: Fix sgl pipeline sample_count mismatch between swapchain (4x MSAA)
-  // and offscreen render textures (1x). The mismatch is harmless on Metal
-  // but triggers validation errors. Proper fix: match sample counts or use
-  // per-pass sgl pipelines.
-  // Validation is enabled (no disable_validation).
+  // sgl sample_count: the default sgl context here matches the swapchain (4x
+  // MSAA); offscreen render textures are drawn through their own per-texture
+  // sgl_context created with the render texture's sample_count (see
+  // load_render_texture + begin_texture_mode in drawing_helpers.h), so each
+  // pass draws with a pipeline whose sample_count matches its target. Validation
+  // is enabled (no disable_validation).
   sg_setup(&desc);
   stm_setup();
   g_start_time = stm_now();


### PR DESCRIPTION
## What
While auditing the sokol backend's GPU lifecycle (the correctness pass behind #57–#60), I found the `sokol_init_cb` comment is **stale and misleading**:

> ```
> // TODO: Fix sgl pipeline sample_count mismatch between swapchain (4x MSAA)
> // and offscreen render textures (1x). ... Proper fix: ... per-pass sgl pipelines.
> ```

That fix **already exists in the code**:
- `load_render_texture` creates a **per-render-texture `sgl_context`** with the render texture's own `sample_count` (drawing_helpers.h ~L980).
- `begin_texture_mode` switches to it via `sgl_set_context({rt.sgl_ctx_id})` for the offscreen pass, and `end_texture_mode` restores the default (swapchain-matched) context.

So every pass already draws through a pipeline whose `sample_count` matches its target — the exact 'proper fix' the TODO asks for. The comment describes an unsolved problem that isn't unsolved.

## Change
Replace the TODO with an accurate note explaining the per-context sample-count matching, so a future maintainer doesn't chase a non-bug or 'fix' working code. **Comment-only, no behavior change** — metal demo compiles clean.

Housekeeping companion to the sokol correctness pass (#57 texture-load leak, #58 render-target leak, #59 capture dims, #60 sector NaN).