### PR TITLE
fix(raylib): guard null image data in render-texture capture paths

### DIFF
--- a/src/backends/raylib/drawing_helpers.h
+++ b/src/backends/raylib/drawing_helpers.h
@@ -502,8 +502,11 @@ inline void draw_texture_pro(TextureType tex, RectangleType src, RectangleType d
 inline bool capture_render_texture(const graphics::RenderTextureType &rt,
                                    const std::filesystem::path &path) {
   raylib::Image img = raylib::LoadImageFromTexture(rt.texture);
-  if (img.data == nullptr) // readback failed (invalid/unloaded texture)
+  if (img.data == nullptr) { // readback failed (invalid/unloaded texture)
+    log_error("capture_frame: texture readback returned a null image "
+              "(invalid/unloaded render texture)");
     return false;
+  }
   raylib::ImageFlipVertical(&img);
   bool ok = raylib::ExportImage(img, path.c_str());
   raylib::UnloadImage(img);

--- a/src/backends/raylib/drawing_helpers.h
+++ b/src/backends/raylib/drawing_helpers.h
@@ -502,6 +502,8 @@ inline void draw_texture_pro(TextureType tex, RectangleType src, RectangleType d
 inline bool capture_render_texture(const graphics::RenderTextureType &rt,
                                    const std::filesystem::path &path) {
   raylib::Image img = raylib::LoadImageFromTexture(rt.texture);
+  if (img.data == nullptr) // readback failed (invalid/unloaded texture)
+    return false;
   raylib::ImageFlipVertical(&img);
   bool ok = raylib::ExportImage(img, path.c_str());
   raylib::UnloadImage(img);

--- a/src/backends/raylib/headless.h
+++ b/src/backends/raylib/headless.h
@@ -11,6 +11,7 @@
 
 #include "../../graphics/platform/headless_gl.h"
 #include "../../graphics_common.h"
+#include "../../logging.h"
 
 namespace afterhours::graphics {
 
@@ -141,8 +142,11 @@ struct RaylibHeadless {
 
     // Get image from texture
     raylib::Image img = raylib::LoadImageFromTexture(render_texture.texture);
-    if (img.data == nullptr) // readback failed (invalid/unloaded texture)
+    if (img.data == nullptr) { // readback failed (invalid/unloaded texture)
+      log_error("capture_frame: texture readback returned a null image "
+                "(invalid/unloaded render texture)");
       return false;
+    }
     raylib::ImageFlipVertical(&img);
 
     // Export using raylib (uses stb_image_write internally)

--- a/src/backends/raylib/headless.h
+++ b/src/backends/raylib/headless.h
@@ -141,6 +141,8 @@ struct RaylibHeadless {
 
     // Get image from texture
     raylib::Image img = raylib::LoadImageFromTexture(render_texture.texture);
+    if (img.data == nullptr) // readback failed (invalid/unloaded texture)
+      return false;
     raylib::ImageFlipVertical(&img);
 
     // Export using raylib (uses stb_image_write internally)

--- a/src/backends/raylib/windowed.h
+++ b/src/backends/raylib/windowed.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "../../graphics_common.h"
+#include "../../logging.h"
 
 namespace afterhours::graphics {
 
@@ -113,8 +114,11 @@ struct RaylibWindowed {
   /// @return true if the export succeeded, false otherwise.
   bool capture_frame(const std::filesystem::path &path) {
     raylib::Image img = raylib::LoadImageFromTexture(render_texture.texture);
-    if (img.data == nullptr) // readback failed (invalid/unloaded texture)
+    if (img.data == nullptr) { // readback failed (invalid/unloaded texture)
+      log_error("capture_frame: texture readback returned a null image "
+                "(invalid/unloaded render texture)");
       return false;
+    }
     raylib::ImageFlipVertical(&img);
     bool success = raylib::ExportImage(img, path.c_str());
     raylib::UnloadImage(img);

--- a/src/backends/raylib/windowed.h
+++ b/src/backends/raylib/windowed.h
@@ -113,6 +113,8 @@ struct RaylibWindowed {
   /// @return true if the export succeeded, false otherwise.
   bool capture_frame(const std::filesystem::path &path) {
     raylib::Image img = raylib::LoadImageFromTexture(render_texture.texture);
+    if (img.data == nullptr) // readback failed (invalid/unloaded texture)
+      return false;
     raylib::ImageFlipVertical(&img);
     bool success = raylib::ExportImage(img, path.c_str());
     raylib::UnloadImage(img);


### PR DESCRIPTION
## Problem
Three raylib capture functions do `LoadImageFromTexture()` then immediately `ImageFlipVertical(&img)` with **no validity check**. If the readback fails (invalid or unloaded render texture, failed GPU read), raylib returns an `Image` with `data == nullptr`, and `ImageFlipVertical` dereferences it → crash / UB.

The sibling `capture_render_texture_to_memory` **already guards** this exact case (`if (img.data == nullptr) return {};`), so the fix is just consistency. The three that didn't:
- `drawing_helpers.h` — `capture_render_texture`
- `windowed.h` — `RenderContext::capture_frame`
- `headless.h` — `capture_frame`

## Fix
Add `if (img.data == nullptr) return false;` right after the `LoadImageFromTexture` in all three (each returns `bool`), before any `ImageFlipVertical`.

## Verification
- `drawing_helpers.h`, `windowed.h`, `headless.h` all compile clean under `-Wall -Wextra` with raylib.
- +6 lines, pure guard, no behavior change on the success path.

Continues the GPU-resource-lifecycle correctness pass — the raylib-backend counterpart to the sokol fixes (#57 texture-load, #58 render-target, #59 capture dims, #60 sector NaN).