### PR TITLE
fix(library): Library::get() degrades gracefully on missing key (was throw/abort)

### DIFF
--- a/src/library.h
+++ b/src/library.h
@@ -60,21 +60,31 @@ template <typename T> struct Library {
   }
 
   [[nodiscard]] T &get(const std::string &name) {
-    if (!this->contains(name)) {
+    auto it = storage.find(name);
+    if (it == storage.end()) {
       log_warn("asking for item: {} but nothing has been loaded with that "
                "name yet {}",
                name.c_str(), type_name<T>());
+      // Degrade gracefully to a default-constructed fallback instead of
+      // storage.at() throwing std::out_of_range (a hard abort under
+      // -fno-exceptions). Static so we can return a reference.
+      static T missing{};
+      missing = T{}; // reset each miss so callers can't corrupt the fallback
+      return missing;
     }
-    return storage.at(name);
+    return it->second;
   }
 
   [[nodiscard]] const T &get(const std::string &name) const {
-    if (!this->contains(name)) {
+    auto it = storage.find(name);
+    if (it == storage.end()) {
       log_warn("asking for item: {} but nothing has been loaded with that "
                "name yet for {}",
                name.c_str(), type_name<T>());
+      static const T missing{};
+      return missing;
     }
-    return storage.at(name);
+    return it->second;
   }
 
   [[nodiscard]] bool contains(const std::string &name) const {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,6 +45,7 @@ ALL_TESTS := \
 	entity_pool_test \
 	entity_query_test \
 	input_injector_mouse_delta_test \
+	library_get_test \
 	progress_bar_test \
 	render_order_test \
 	slider_test \
@@ -70,6 +71,9 @@ entity_mapping_test: entity_mapping_test.cpp ../examples/entity_mapping_test_hel
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@
 
 entity_pool_test: entity_pool_test.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@
+
+library_get_test: library_get_test.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@
 
 entity_query_test: entity_query_test.cpp

--- a/tests/library_get_test.cpp
+++ b/tests/library_get_test.cpp
@@ -1,0 +1,68 @@
+// Regression test for Library<T>::get() graceful degradation on a missing key.
+//
+// Before: get() on an unloaded name logged a warning but then fell through to
+// storage.at(name), which throws std::out_of_range (a hard abort under
+// -fno-exceptions, which consumer games build with). This test locks in that a
+// miss now returns a default-constructed fallback instead of throwing/aborting,
+// and that the non-const overload resets the fallback each miss so a caller
+// can't corrupt the shared fallback for later misses.
+
+#include <afterhours/src/library.h>
+
+#include <cstdio>
+#include <string>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static void check(bool cond, const char *what) {
+  tests_run++;
+  if (cond) {
+    tests_passed++;
+    printf("  PASS: %s\n", what);
+  } else {
+    printf("  FAIL: %s\n", what);
+  }
+}
+
+// Library<T> is abstract (pure-virtual unload + convert_filename_to_object);
+// minimal concrete subclass.
+template <typename T> struct TestLibrary : Library<T> {
+  void unload(T) override {}
+  T convert_filename_to_object(const char *, const char *) override {
+    return T{};
+  }
+};
+
+int main() {
+  printf("=== Library<T>::get() missing-key degradation ===\n\n");
+
+  // int payload: default-constructs to 0, easy to assert on.
+  TestLibrary<int> lib;
+  lib.add("real", 42);
+
+  // 1. hit path returns the stored value
+  check(lib.get("real") == 42, "get(existing) returns the stored value (42)");
+
+  // 2. MISS path returns a default-constructed fallback instead of throwing.
+  //    (Before the fix this line threw std::out_of_range / aborted.)
+  int &miss = lib.get("does_not_exist");
+  check(miss == 0, "get(missing) returns default-constructed fallback (0), no throw");
+
+  // 3. non-const overload resets the fallback each miss: mutating the returned
+  //    fallback must not leak into a subsequent miss.
+  miss = 999;
+  int &miss2 = lib.get("also_missing");
+  check(miss2 == 0, "fallback is reset per miss (prior miss mutation does not leak)");
+
+  // 4. const overload miss also degrades (returns fallback, no throw)
+  const TestLibrary<int> &clib = lib;
+  check(clib.get("nope") == 0, "const get(missing) returns fallback, no throw");
+
+  // 5. a miss did not corrupt real entries
+  check(lib.get("real") == 42, "hit still correct after misses");
+
+  printf("\n%d/%d checks passed\n", tests_passed, tests_run);
+  if (tests_passed != tests_run) { printf("FAILURES: %d\n", tests_run - tests_passed); return 1; }
+  printf("All checks passed!\n");
+  return 0;
+}


### PR DESCRIPTION
## Problem
Both `Library<T>::get()` overloads did `if (!contains(name)) { log_warn(...); }` then `return storage.at(name)` — the `contains` check only **logs**, then falls through to `storage.at(name)`, which **throws `std::out_of_range`** on a miss (and **hard-aborts under `-fno-exceptions`**, which the consumer games commonly build with). So the warning implies graceful degradation that never happens: asking for a missing texture/font/sound name **crashes** instead of degrading.

`Library<T>` owns real resource handles (SoundLibrary, MusicLibrary), so a mistyped/unloaded name is a realistic runtime path.

## Fix
On a miss, return a **default-constructed fallback `T&`** (matching the warning's intent) instead of letting `.at()` throw. Single-threaded ECS, so the `static` fallback is fine; the non-const overload resets it on each miss so a caller can't corrupt the shared fallback for subsequent misses. Also switches the hit path to a single `find` (was `contains` + `at` = two lookups).

## Test plan
Added `tests/library_get_test.cpp` — a real compiled+run regression test (backend-neutral, wired into `tests/Makefile` ALL_TESTS), run on boulder (clang, C++23). **Same test binary, before vs after** — proves the behavior change, not just that it compiles:

**BEFORE** (pre-fix `library.h`) — aborts on the first miss:
```
  PASS: get(existing) returns the stored value (42)
[WARN] asking for item: does_not_exist but nothing has been loaded ...
libc++abi: terminating due to uncaught exception of type std::out_of_range: map::at: key not found
exit=134   (SIGABRT; under -fno-exceptions this is a silent hard abort)
```

**AFTER** (this branch) — degrades gracefully, 5/5 pass:
```
  PASS: get(existing) returns the stored value (42)
  PASS: get(missing) returns default-constructed fallback (0), no throw
  PASS: fallback is reset per miss (prior miss mutation does not leak)
  PASS: const get(missing) returns fallback, no throw
  PASS: hit still correct after misses
5/5 checks passed -- All checks passed!  (exit=0)
```

Also: `ah.h` umbrella, metal demo, and kart consumer all compile 0 errors.

Continues the correctness pass — from GPU-resource lifecycle (#57-#62) into the resource-owning `Library<T>`.
