### PR TITLE
fix(sound): guard play() on missing name + portable play_random_match

### DIFF
--- a/src/plugins/sound_system.h
+++ b/src/plugins/sound_system.h
@@ -41,11 +41,22 @@ struct sound_system : developer::Plugin {
         }
 
         void play(const char *const name) {
+            if (!contains(name)) {
+                log_warn("SoundLibrary::play: no sound loaded named '{}'", name);
+                return;
+            }
             ::afterhours::PlaySound(get(name));
         }
 
         void play_random_match(const std::string &prefix) {
-            impl.get_random_match(prefix).transform(::afterhours::PlaySound);
+            // Explicit has_value/value instead of .transform(): the latter is a
+            // C++23 monadic op that std::expected has but the tl::expected
+            // fallback (used when <expected> is unavailable, e.g. gcc 11) does
+            // not, so .transform() fails to compile there.
+            auto match = impl.get_random_match(prefix);
+            if (match.has_value()) {
+                ::afterhours::PlaySound(match.value());
+            }
         }
 
         void play_if_none_playing(const std::string &prefix) {
@@ -129,6 +140,11 @@ struct sound_system : developer::Plugin {
         }
 
         void play(const std::string &name) {
+            if (!contains(name)) {
+                log_warn("MusicLibrary::play: no music loaded named '{}'",
+                         name.c_str());
+                return;
+            }
             auto &music = get(name);
             ::afterhours::PlayMusicStream(music);
         }
@@ -267,7 +283,8 @@ struct sound_system : developer::Plugin {
                         }
                     }
                 }
-                // play(name) still throws on a missing base, matching get().
+                // On a missing base, play(name) logs and no-ops (it
+                // contains-guards); no exception.
                 if (lib.contains(base)) {
                     ::afterhours::PlaySound(lib.get(base));
                 } else {


### PR DESCRIPTION
Two fixes in the sound system, both surfaced while auditing it (the correctness pass, after the resource-owning `Library<T>` in #63).

## 1. `play()` didn't guard a missing name
`SoundLibrary::play()` and `MusicLibrary::play()` called `get(name)` with no `contains()` check. After the `Library::get()` fix (#63) a miss returns a **default-constructed** Sound/Music, so `play()` would hand raylib a **zero Sound / MusicStream** (`PlaySound`/`PlayMusicStream` on a null-buffer stream — undefined on older raylib). Guard both with `contains()` → log + no-op on a miss, so a mistyped/unloaded name never reaches raylib with a null stream. Also updates the now-stale `// play(name) still throws on a missing base` comment (it no longer throws after #63).

## 2. `play_random_match` didn't compile on no-`<expected>` toolchains
It used `ah_std::expected::transform()` — a **C++23 monadic op** that `std::expected` has but the `tl::expected` fallback (used when `<expected>` is unavailable, e.g. gcc 11, or this Mac's libc++) does **not**. So `sound_system.h` **failed to compile at all** on those toolchains. Replaced with explicit `has_value()`/`value()`, which works on both.

## Verification
- `sound_system.h` compiles **0 errors/warnings** under `-Wall -Wextra` (before this, it didn't compile on a no-`<expected>` toolchain — the `.transform` error).
- kart consumer compiles clean.

Pairs with #63 (Library::get graceful miss) and the gcc-11/older-stdlib portability line (#48/#54).