### PR TITLE
fix(animation): reset sprite-sheet position on loop, not just frame counter

### DIFF
--- a/src/plugins/texture_manager.h
+++ b/src/plugins/texture_manager.h
@@ -202,6 +202,11 @@ struct AnimationUpdateCurrentFrame : System<HasAnimation> {
         return;
       }
       hasAnimation.params.cur_frame = 0;
+      // Also rewind the sprite-sheet position, not just the frame counter.
+      // Otherwise a looping animation keeps advancing cur_frame_position each
+      // loop (row j grows unbounded), so after the first loop it samples the
+      // wrong — eventually out-of-sheet — cells.
+      hasAnimation.cur_frame_position = hasAnimation.start_position();
     }
 
     const auto [i, j] =


### PR DESCRIPTION
## Problem
`AnimationUpdateCurrentFrame`, when `cur_frame` reaches `total_frames` on a **looping** (`once=false`) animation, resets `params.cur_frame = 0` but **leaves `cur_frame_position` untouched**.

Each tick advances `cur_frame_position` via `idx_to_next_sprite_location`, which wraps the column `i` at the sheet width but grows the row `j` **unbounded**. So the frame *counter* loops `0..N` while the frame *position* keeps marching forward — meaning:
- the 2nd loop onward samples the **wrong sprite cells** (offset by however far the first loop got), and
- row `j` eventually walks **off the sheet** into garbage / out-of-bounds regions.

A one-shot (`once=true`) animation is unaffected (it cleans up at the end); this only bites looping animations, which are the common case.

## Fix
Reset `cur_frame_position = start_position()` alongside the `cur_frame = 0` reset, so every loop replays from the same starting cell the first loop did. This is symmetric with the constructor, which initializes `cur_frame_position` to `start_position`.

## Verification
- `texture_manager.h` compiles clean under `-Wall -Wextra`.
- metal demo + kart consumer compile 0 errors.

Continues the resource/state-lifecycle correctness pass (#57–#64) into the animation system.