### PR TITLE
fix(sokol): log when fontstash atlas creation fails at init

### DIFF
--- a/src/backends/sokol/backend.h
+++ b/src/backends/sokol/backend.h
@@ -158,6 +158,12 @@ inline void sokol_init_cb() {
   sfons_desc.width = 2048;
   sfons_desc.height = 2048;
   g_fons_ctx = sfons_create(&sfons_desc);
+  if (g_fons_ctx == nullptr) {
+    // Atlas allocation failed (e.g. GPU OOM at startup). All text calls guard
+    // on !g_fons_ctx and become no-ops, so this manifests as silently missing
+    // text app-wide — log it loudly so it's diagnosable rather than baffling.
+    log_error("sfons_create failed (2048x2048 atlas); text rendering disabled");
+  }
 
   g_initialized = true;
 


### PR DESCRIPTION
## What
`sokol_init_cb` did `g_fons_ctx = sfons_create(...)` **unchecked**, then set `g_initialized = true` regardless. If the 2048×2048 font atlas fails to allocate (GPU OOM at startup), `g_fons_ctx` is null — and every text path (`draw_text_ex`, `measure_text`, `load_font_from_file`) correctly guards `!ctx` and **silently no-ops**. So the failure manifests as **text silently missing app-wide with zero diagnostic** — baffling to debug.

The backend logs its other init/load failures (`load_shader` logs null/missing paths, the window-op stubs log, etc.), so swallowing this one was an inconsistency.

## Fix
Add a loud `log_error` when `g_fons_ctx == nullptr` after `sfons_create`, so the failure is diagnosable instead of silent. Behavior is otherwise unchanged — the text paths already guard null ctx, so this doesn't crash or alter the happy path.

## Verification
Metal demo (incl. the `SOKOL_IMPL` TU where `sokol_init_cb` lives) compiles clean. +6 lines.

Same 'surface the failure, don't swallow it' theme as #57–#59 (which fixed unchecked `sg_make_*`). The rest of the fontstash system (`load_font_from_file` ctx/FONS_INVALID/MAX_FONTS guards, `measure_text`) I audited and it's already correct — this init check was the one gap.