### PR TITLE
fix(ui): skip stale child ids in set_visibility (null-deref on cleaned child)

### DIFF
--- a/src/plugins/ui/systems.h
+++ b/src/plugins/ui/systems.h
@@ -62,6 +62,14 @@ static inline RectangleType apply_scroll_offset(const Entity &entity,
 struct UIEntityMappingCache : BaseComponent {
   std::vector<Entity *> components;
 
+  // Whether `id` maps to a live entity in this frame's mapping. A stale child
+  // id (e.g. a child cleaned up while its parent still lists it) is NOT
+  // contained, so callers can skip it instead of dereferencing null in to_ent.
+  [[nodiscard]] bool contains(EntityID id) const {
+    return id >= 0 && static_cast<size_t>(id) < components.size() &&
+           components[id] != nullptr;
+  }
+
   Entity &to_ent(EntityID id) {
     if (id < 0 || static_cast<size_t>(id) >= components.size() ||
         components[id] == nullptr) {
@@ -398,6 +406,10 @@ struct TrackIfComponentWillBeRendered : System<> {
 
     // Process children first (bottom-up approach for better early exits)
     for (EntityID child : cmp.children) {
+      // Skip stale child ids (child cleaned up while still listed in the
+      // parent) — otherwise to_cmp->to_ent dereferences a null mapping slot.
+      if (!cache->contains(child))
+        continue;
       set_visibility(cache->to_cmp(child));
     }
 


### PR DESCRIPTION
## Problem
`UIComponent` stores `children` as `EntityID`s. If a child entity is cleaned up while its parent still lists that id (a stale child id), `set_visibility` iterated `cmp.children` and called `cache->to_cmp(child)` → `UIEntityMappingCache::to_ent(child)`, whose invalid/missing branch:
```cpp
if (id < 0 || id >= components.size() || components[id] == nullptr) {
  log_error("...not in mapping");   // logs...
}
return *components[id];               // ...then dereferences the null slot => crash
```
Same warn-then-deref-null shape as the `Library::get()` (#63) and raylib capture (#62) bugs. Unlike the sibling child loops in this same file (`RunAutoLayout` etc., which do `getEntityForID(child_id)` + `if (!valid) continue`), `set_visibility` had no guard.

## Fix
- Add `UIEntityMappingCache::contains(id)` (bounds + non-null check).
- Guard the `set_visibility` child recursion with it, skipping stale ids — matching the guard pattern the other child loops already use.

Minimal, consistent, no behavior change for live children.

## Verification
metal demo + kart consumer both compile clean.

Continues the lifecycle/dangling-ref correctness pass (#57–#66) into the UI parent/child graph. Note: `autolayout.h::to_ent` has the same warn-then-deref-null shape; its call sites (line 644 etc.) mostly bounds-guard first, but hardening `to_ent` itself could be a follow-up — flagged, not folded in to keep this focused.