### PR TITLE
fix(tests): portable mouse-delta backend checks (brew-prefix + pin afterhours include)

### DIFF
--- a/tests/run_mouse_delta_backend_checks.sh
+++ b/tests/run_mouse_delta_backend_checks.sh
@@ -7,15 +7,33 @@ INJECTOR_TEST="$ROOT/tests/input_injector_mouse_delta_test.cpp"
 OUT_DIR="$ROOT/output/mouse_delta_checks"
 mkdir -p "$OUT_DIR"
 
+# Pin <afterhours/...> to THIS checkout regardless of the directory's name.
+# A bare `-I "$ROOT/.."` resolves <afterhours/...> to the *parent* of the
+# checkout dir, which only works when the checkout is literally named
+# `afterhours`. In a git worktree (or any differently-named clone) that
+# silently picks up a *sibling* `afterhours` checkout. Generate a private
+# include dir containing a symlink named exactly `afterhours` -> this checkout
+# root, and use it as the sole afterhours root. (Mirrors tests/ + examples/
+# Makefiles.)
+INCLUDE_ROOT="$OUT_DIR/.afh-include"
+mkdir -p "$INCLUDE_ROOT"
+ln -sfn "$ROOT" "$INCLUDE_ROOT/afterhours"
+
+# Homebrew prefix differs per machine (/opt/homebrew on Apple-Silicon default,
+# ~/homebrew for a per-user install). Auto-detect via `brew --prefix raylib`
+# and fall back to the classic Cellar path. Override via RAYLIB_PREFIX env.
+RAYLIB_PREFIX="${RAYLIB_PREFIX:-$(brew --prefix raylib 2>/dev/null)}"
+RAYLIB_PREFIX="${RAYLIB_PREFIX:-/opt/homebrew/Cellar/raylib/5.5}"
+
 echo "==> Running injector delta runtime test"
-clang++ -std=c++23 -I"$ROOT/.." "$INJECTOR_TEST" -o "$OUT_DIR/injector_delta_test"
+clang++ -std=c++23 -isystem "$INCLUDE_ROOT" "$INJECTOR_TEST" -o "$OUT_DIR/injector_delta_test"
 "$OUT_DIR/injector_delta_test"
 
 echo "==> Compile smoke: raylib backend"
 clang++ -std=c++23 \
-  -I/opt/homebrew/Cellar/raylib/5.5/include \
-  -I"$ROOT/vendor" \
-  -I"$ROOT/.." \
+  -I"$RAYLIB_PREFIX/include" \
+  -isystem "$INCLUDE_ROOT" \
+  -isystem "$ROOT/vendor" \
   -DAFTER_HOURS_ENABLE_E2E_TESTING \
   -DAFTER_HOURS_USE_RAYLIB \
   -c "$SMOKE" \
@@ -23,8 +41,8 @@ clang++ -std=c++23 \
 
 echo "==> Compile smoke: sokol backend"
 clang++ -std=c++23 \
-  -I"$ROOT/vendor" \
-  -I"$ROOT/.." \
+  -isystem "$INCLUDE_ROOT" \
+  -isystem "$ROOT/vendor" \
   -DAFTER_HOURS_ENABLE_E2E_TESTING \
   -DAFTER_HOURS_USE_METAL \
   -c "$SMOKE" \


### PR DESCRIPTION
`tests/run_mouse_delta_backend_checks.sh` **fails on boulder today** (and any machine where the checkout isn't literally named `afterhours` beside a sibling, or where raylib isn't at `/opt/homebrew`). Same two portability bugs already fixed for the tests/ and examples/ Makefiles (#42 / #50 / #52) — this closes the last hole.

## Bugs
1. `-I "$ROOT/.."` resolves `<afterhours/...>` to the **parent dir**, so it only works when the checkout is named `afterhours`. In a git worktree or differently-named clone it silently picks up a *sibling* checkout — or, on a fresh clone with no sibling, fails outright:
   ```
   fatal error: 'afterhours/src/plugins/e2e_testing/input_injector.h' file not found
   ```
2. Hardcoded `-I/opt/homebrew/Cellar/raylib/5.5/include` — wrong on per-user Homebrew (`~/homebrew`), wrong on Linux CI, pinned to raylib 5.5.

## Fix (mirrors the Makefiles exactly)
- Generate `output/mouse_delta_checks/.afh-include/afterhours -> this checkout root` and use it as the sole afterhours include root. Works from any worktree / any dir name. The symlink lands in gitignored `output/`, so nothing is tracked.
- Autodetect raylib via `brew --prefix raylib` (Cellar fallback); overridable via `RAYLIB_PREFIX=...`.

## Verified on boulder (`~/homebrew`, worktree not named `afterhours`)
Was failing at step 1 before. Now green end-to-end:
- injector delta runtime test **54/54 passed**
- raylib smoke TU compiles ✓
- sokol smoke TU compiles ✓

Script-only change, no source touched.