### PR TITLE
cleanup(ui): drop dead #if __WIN32 scaffolding in UpdateDropdownOptions

### DIFF
--- a/src/plugins/ui/systems.h
+++ b/src/plugins/ui/systems.h
@@ -1102,27 +1102,11 @@ struct UpdateDropdownOptions
   }
 
   UpdateDropdownOptions()
-      : SystemWithUIContext<HasDropdownState, HasChildrenComponent>() {
-// TODO figure out if this actually will cause trouble
-// Remove include_derived_children since we want to process entities with direct
-// components
-#if __WIN32
-// this->include_derived_children = true;
-#else
-// this->include_derived_children = true;
-#endif
-  }
+      : SystemWithUIContext<HasDropdownState, HasChildrenComponent>() {}
 
-#if __WIN32
-  virtual void for_each_with(Entity &entity, UIComponent &component,
-                             HasDropdownState &hasDropdownState,
-                             HasChildrenComponent &hasChildren, float){
-
-#else
   virtual void for_each_with(Entity &entity, UIComponent &component,
                              HasDropdownState &hasDropdownState,
                              HasChildrenComponent &hasChildren, float) {
-#endif
       // The system should automatically filter entities to only those with
       // required components No need to manually check since
       // SystemWithUIContext<HasDropdownState, HasChildrenComponent> handles


### PR DESCRIPTION
Resolves the `// TODO figure out if this actually will cause trouble` in `UpdateDropdownOptions` — the answer is **no**, it was just dead code.

## Why it's dead
- The constructor's `#if __WIN32 / #else` block had a commented-out `this->include_derived_children = true;` in **both** branches → the whole preprocessor block + its TODO/comments compiled to nothing.
- The `for_each_with` `#if __WIN32 / #else` split declared the **identical** signature in both branches (only textual diff was a `){` vs `) {` brace-spacing typo) → pointless split.
- `__WIN32` (nonstandard double-underscore) is **never defined** anywhere in the repo — only the standard `_WIN32` is used elsewhere (9×) — so these `#if __WIN32` branches were always false and only the `#else` side ever compiled.

Pure no-op simplification: **-17/+1**.

## Scope note
Left the two `#if __WIN32` blocks in `rendering.h` **alone** — those are a real (if misspelled) MinGW bubble-sort fallback for `std::ranges::stable_sort`, i.e. actual behavioral intent, not dead code. Fixing that typo would *activate* an O(n²) sort that isn't stable the way its comment claims and could break the documented pre-order paint invariant, so it's deliberately untouched here.

## Verified
- Compiles clean on **raylib + sokol** backends (smoke TU).
- `dump_ui_test` (exercises the dropdown UI path) compiles.