### PR TITLE
cleanup(ui): single source of truth for dropdown indicator defaults

### DIFF
--- a/src/plugins/ui/component_config.h
+++ b/src/plugins/ui/component_config.h
@@ -149,9 +149,11 @@ struct ComponentConfig {
   std::optional<std::string> checkbox_checked_indicator;
   std::optional<std::string> checkbox_unchecked_indicator;
 
-  // Dropdown indicator characters (default: "v" for closed, "^" for open)
-  // TODO: Replace "v" / "^" with real chevron glyphs (▾ ▴ or ▼ ▲) once
+  // Dropdown indicator characters (default: " v" for closed, " ^" for open)
+  // TODO: Replace " v" / " ^" with real chevron glyphs (▾ ▴ or ▼ ▲) once
   // afterhours ships a built-in icon font or vector glyph set.
+  static constexpr const char *DEFAULT_DROPDOWN_CLOSED = " v";
+  static constexpr const char *DEFAULT_DROPDOWN_OPEN = " ^";
   std::optional<std::string> dropdown_open_indicator;
   std::optional<std::string> dropdown_closed_indicator;
 

--- a/src/plugins/ui/imm_components.h
+++ b/src/plugins/ui/imm_components.h
@@ -1452,13 +1452,16 @@ ElementResult dropdown(HasUIContext auto &ctx, EntityParent ep_pair,
     Entity &trigger = UICollectionHolder::getEntityForIDEnforce(id);
     trigger.get<ui::HasLabel>().label =
         fmt::format("{}{}", std::string(options[opt]),
-                    config.dropdown_closed_indicator.value_or(" v"));
+                    config.dropdown_closed_indicator.value_or(
+                        ComponentConfig::DEFAULT_DROPDOWN_CLOSED));
     ctx.set_focus(trigger.id);
   };
 
   auto current_option = std::string(options[dropdownState.last_option_clicked]);
-  auto drop_closed = config.dropdown_closed_indicator.value_or(" v");
-  auto drop_open = config.dropdown_open_indicator.value_or(" ^");
+  auto drop_closed = config.dropdown_closed_indicator.value_or(
+      ComponentConfig::DEFAULT_DROPDOWN_CLOSED);
+  auto drop_open = config.dropdown_open_indicator.value_or(
+      ComponentConfig::DEFAULT_DROPDOWN_OPEN);
   auto drop_arrow_icon = dropdownState.on ? drop_open : drop_closed;
   auto main_button_label = fmt::format("{}{}", current_option, drop_arrow_icon);
   // TODO hot sibling summary: previously, when a label was present to the


### PR DESCRIPTION
The default dropdown indicator strings (` v` closed, ` ^` open) were hardcoded as bare literals at **three** call sites in `imm_components.h` via `.value_or(" v")` / `.value_or(" ^")` — with ` v` **duplicated** across two of them (the click-callback label update and the initial main-button render).

If the default were ever changed in one spot (e.g. to the real chevron glyph the adjacent TODO calls for), the others would silently keep ` v` and the dropdown would show **inconsistent indicators depending on code path**.

Fix: hoist them into named constants on `ComponentConfig` — `DEFAULT_DROPDOWN_CLOSED` / `DEFAULT_DROPDOWN_OPEN` — mirroring the existing `DEFAULT_CHECKBOX_CHECKED/UNCHECKED` pattern right above, and reference those at every `value_or()` site. Single source of truth; the eventual glyph swap becomes a one-line change.

**Pure refactor:** the constant values (` v` / ` ^`) are byte-identical to the literals they replace → zero behavior/render change. Verified compiles clean on **raylib + sokol** backends.