### PR TITLE
test(autolayout): fix margin_fits_within_parent — percent(1.0)+margin overflows by design (3 red → 2)

### DIFF
--- a/tests/autolayout_test.cpp
+++ b/tests/autolayout_test.cpp
@@ -598,9 +598,11 @@ TEST(screen_pct_half) {
 }
 
 // ---------------------------------------------------------------------------
-// Margin does not overflow parent: child with margins fits within parent
+// percent(1.0) child + margin overflows the parent on the cross axis by
+// design (content-box model: percent fills 100% of content area, margin then
+// offsets position). See d41e1d8.
 // ---------------------------------------------------------------------------
-TEST(margin_fits_within_parent) {
+TEST(margin_offsets_percent_child_into_overflow) {
   TestLayout t;
   auto &root = t.make_ui(pixels(300), pixels(300));
   t.ui(root).set_flex_direction(FlexDirection::Column);
@@ -611,11 +613,19 @@ TEST(margin_fits_within_parent) {
   t.add_child(root, child);
   t.run(root);
 
-  // Child rect should be within parent bounds (margin is inside the box)
+  // Post-d41e1d8 content-box model: percent(1.0f) resolves to 100% of the
+  // parent's content area (300) WITHOUT subtracting margin, and margin then
+  // offsets the position. So a full-width child + margin overflows the parent
+  // by design on the cross axis — the child's own size is the content box, not
+  // a margin-inset box. (Cross axis in a Column gets no error correction.)
   auto r = t.ui(child).rect();
   CHECK(r.x >= 0.f);
   CHECK(r.y >= 0.f);
-  CHECK(r.x + r.width <= 300.f + 1.f);
+  // cross axis (X): full content-box width, offset by margin -> right edge 310
+  CHECK_APPROX(r.x, 10.f);
+  CHECK_APPROX(r.width, 300.f);
+  CHECK_APPROX(r.x + r.width, 310.f);
+  // main axis (Y): pixels(100) child + 10 margin offset fits within the 300 parent
   CHECK(r.y + r.height <= 300.f + 1.f);
 }
 


### PR DESCRIPTION
One of the 3 assertions #68 deliberately left failing. I instrumented the **live solver** (dumped `computed[]`/`computed_margin[]`/`rect()`) to settle whether each is a stale test or a real bug. This one is **stale**.

## Finding
`margin_fits_within_parent` asserted a `percent(1.0f)` child + `pixels(10)` margin stays within its parent (right edge ≤ 301). But post-`d41e1d8` the content-box model resolves `percent` against **100% of the parent content area without subtracting margin** (computed width = 300), and margin then **offsets position** (x = 10). X is the *cross* axis in a Column → no error correction → child keeps full 300 width → right edge **310**.

Live rect confirms: `x=10 width=300 right=310` (Y fits: pixels(100)+10 margin = 110 ≤ 300).

That overflow is the intended semantic — making `percent` account for its own margin would silently break the content-box contract everywhere. The test's *"margin is inside the box"* premise is what's stale.

## Change
Renamed → `margin_offsets_percent_child_into_overflow`, assert the documented behavior (x=10, width=300, right edge=310; Y still fits). **autolayout_test: 3 red → 2 red.**

## Left for a separate decision (NOT in this PR)
The remaining 2 (`flow_large_margin_clamps_to_zero`) are a genuine solver question:
- **width** should be **512** (cross axis, uncorrected — the test's "clamps to 0" premise is wrong)
- **height** is **288** if the main-axis error-solver converges (element shrinks so element+margins fill the 720 axis), but a 10-iteration cap in `solve_violations` freezes the geometric convergence early at the observed **333.19**. So neither the test's `0` nor the code's `333.19` is the *correct* layout value.

That one needs a call: assert-what-code-does (333.19, test-only) vs fix-the-solver-cap (→288, touches core layout math). Deliberately not folded in here.

Test-only change. Verified: builds + runs, the renamed test passes.