### PR TITLE
fix(raylib): declare GL on Linux headless capture path (glFlush/glFinish)

### DIFF
--- a/src/backends/raylib/headless.h
+++ b/src/backends/raylib/headless.h
@@ -9,6 +9,13 @@
 #include <dlfcn.h>
 #endif
 
+// capture_frame() calls glFlush()/glFinish() directly. On macOS these come in
+// transitively via headless_gl_macos.h's <OpenGL/gl3.h>; on Linux nothing in
+// the include chain declares them, so pull the system GL header explicitly.
+#if defined(__linux__)
+#include <GL/gl.h>
+#endif
+
 #include "../../graphics/platform/headless_gl.h"
 #include "../../graphics_common.h"
 #include "../../logging.h"


### PR DESCRIPTION
`headless.h`'s `capture_frame()` calls `glFlush()`/`glFinish()` directly. On macOS these are declared transitively via `headless_gl_macos.h`'s `<OpenGL/gl3.h>`, but on Linux nothing in the include chain declares them, so a raylib build on Linux fails:

```
headless.h:140:5: error: use of undeclared identifier 'glFlush'
headless.h:141:5: error: use of undeclared identifier 'glFinish'
```

Same `__APPLE__`-only-worked class as the tag-filter #if guard (#49). Surfaced by the new Linux CI (#53), whose `Compile-check raylib/UI tests` step got this far after the earlier install/header-search fixes.

## Fix
Pull the system `<GL/gl.h>` explicitly on `__linux__`, mirroring how the macOS path already obtains GL. `__linux__`-guarded so macOS is untouched.

## Test plan
- **macOS (boulder, clang):** `dump_ui_test` (pulls backend.h → headless.h) compiles clean — no regression from the guarded include.
- **Linux:** provides the missing `glFlush`/`glFinish` declarations via Mesa's `GL/gl.h`. #53's CI installs `libgl-dev` and will exercise this on the ubuntu runner (companion CI change).

Note: Linux headless *runtime* is still a stub (`headless_gl_linux.h` asserts "use Xvfb"); this only fixes the **compile** so the raylib backend builds on Linux. Runtime headless-on-Linux is separate/out of scope.