### PR TITLE
feat(sokol): headless virtual resize (honor resize with no window)

### DIFF
--- a/src/backends/sokol/backend.h
+++ b/src/backends/sokol/backend.h
@@ -315,7 +315,22 @@ struct MetalPlatformAPI {
   static void minimize_window() {
     log_error("@notimplemented minimize_window");
   }
-  static void set_window_size(int, int) {
+  static void set_window_size(int w, int h) {
+    // Headless: there is no window, but we can honor a resize by re-sizing the
+    // offscreen render target + reported screen dims, so layout/e2e that depend
+    // on a specific viewport size work windowlessly. Called on resize events
+    // only (not per-frame), so recreating the render texture here is fine.
+    if (metal_detail::g_headless) {
+      if (w <= 0 || h <= 0)
+        return;
+      if (w == metal_detail::g_headless_w && h == metal_detail::g_headless_h)
+        return;
+      metal_detail::g_headless_w = w;
+      metal_detail::g_headless_h = h;
+      ::afterhours::unload_render_texture(metal_detail::g_headless_rt);
+      metal_detail::g_headless_rt = ::afterhours::load_render_texture(w, h);
+      return;
+    }
     log_error("@notimplemented set_window_size");
   }
   static void set_window_min_size(int, int) {

--- a/src/plugins/window_manager.h
+++ b/src/plugins/window_manager.h
@@ -10,6 +10,7 @@
 #include "../core/entity_query.h"
 #include "../core/system.h"
 #include "../developer.h"
+#include "../graphics.h"  // graphics::is_headless / set_window_size / metal_detail
 #include "../logging.h"
 
 // Forward declarations for Metal/Sokol backend (defined in sokol_app.h and
@@ -84,11 +85,12 @@ struct window_manager : developer::Plugin {
   // resolution and an extern Obj-C function for resizing.
   static Resolution fetch_current_resolution() {
     // Return logical (CSS) pixel dimensions so the UI works consistently
-    // regardless of DPI scale.
-    float dpi = ::sapp_dpi_scale();
+    // regardless of DPI scale. The metal_detail accessors return the headless
+    // offscreen size (dpi=1) when there is no window.
+    float dpi = graphics::metal_detail::dpi_scale();
     return Resolution{
-        .width = static_cast<int>(static_cast<float>(::sapp_width()) / dpi),
-        .height = static_cast<int>(static_cast<float>(::sapp_height()) / dpi),
+        .width = static_cast<int>(static_cast<float>(graphics::metal_detail::screen_w()) / dpi),
+        .height = static_cast<int>(static_cast<float>(graphics::metal_detail::screen_h()) / dpi),
     };
   }
 
@@ -98,8 +100,13 @@ struct window_manager : developer::Plugin {
     return Resolution{.width = 3840, .height = 2160};
   }
 
-  // Implemented in sokol_impl.mm via Cocoa NSWindow API.
+  // Windowed: Cocoa NSWindow resize (sokol_impl.mm). Headless: no window, so
+  // resize the offscreen render target instead (MetalPlatformAPI::set_window_size).
   static void set_window_size(const int width, const int height) {
+    if (graphics::is_headless()) {
+      graphics::set_window_size(width, height);
+      return;
+    }
     ::metal_set_window_size(width, height);
   }
 #else


### PR DESCRIPTION
Adds headless virtual-resize support: honor resize requests when running windowless (offscreen). Builds on the headless sokol rendering merged in #76.

Single commit 994cdb0 on top of main.